### PR TITLE
Add initial Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.nyc_output
+.github
+coverage
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:current-alpine3.12
 
-RUN apk update && apk add --no-cache mongodb-tools
+RUN apk update
 
 COPY . /var/src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:current-alpine3.12
+
+RUN apk update && apk add --no-cache mongodb-tools
+
+COPY . /var/src
+
+WORKDIR /var/src
+
+RUN npm install --only=prod
+
+EXPOSE 8080 8080
+
+ENTRYPOINT ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
 ## Postman collection
 [Postman collection for the Rick and Morty API](https://github.com/loopDelicious/rick-and-morty-postman) by [loopDelicious](https://github.com/loopDelicious)
 
+## Run with Docker
+You can try out `rick-and-morty-api` locally with some mock data by using [Docker](https://docs.docker.com/get-docker/) by running `docker compose up`.
+> (Tested on `Docker 20.10.8`)
 
 ## JavaScript client
 The Rick and Morty API JavaScript client is a [fully typed](https://javascript.rickandmortyapi.com/modules/interfaces.html) client that gives you access to the API and its features. 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,15 @@
 [Postman collection for the Rick and Morty API](https://github.com/loopDelicious/rick-and-morty-postman) by [loopDelicious](https://github.com/loopDelicious)
 
 ## Run with Docker
-You can try out `rick-and-morty-api` locally with some mock data by using [Docker](https://docs.docker.com/get-docker/) by running `docker compose up`.
-> (Tested on `Docker 20.10.8`)
+
+You can try out `rick-and-morty-api` locally with [Docker](https://docs.docker.com/get-docker/). To do this you need:
+
+1. Install Docker
+2. Clone the repo.
+3. Run `docker compose up`
+4. The API will be running on port `8080`.
+
+> Note: this Docker instance will run with test/dev resources (not the full DB available at [rickandmortyapi.com](https://rickandmortyapi.com/))
 
 ## JavaScript client
 The Rick and Morty API JavaScript client is a [fully typed](https://javascript.rickandmortyapi.com/modules/interfaces.html) client that gives you access to the API and its features. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  mongodb:
+    image: mongo:5.0.2
+    restart: unless-stopped
+    env_file: ./.env
+    ports:
+      - 27017:27017
+    volumes:
+      - ./mongorestore.sh:/docker-entrypoint-initdb.d/mongorestore.sh
+      - ./test/data:/db-dump
+    networks:
+      - rick-and-morty-api-net
+  app:
+    depends_on:
+      - mongodb
+    image: rick-and-morty-api:latest
+    restart: unless-stopped
+    build:
+      dockerfile: Dockerfile
+    environment:
+      - NODE_ENV=production
+      - DATABASE=mongodb://mongodb:27017/rickmorty
+    ports:
+      - 8080:8080
+    networks:
+      - rick-and-morty-api-net
+networks:
+  rick-and-morty-api-net:
+    driver: bridge

--- a/mongorestore.sh
+++ b/mongorestore.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+mongorestore -d rickmorty /db-dump


### PR DESCRIPTION
## Purpose of this PR

@afuh 👋 

This PR adds initial Docker support in case folks want to try out the `rick-and-morty-api` locally with some mock data.

To do this they need to:
1. Install [Docker](https://docs.docker.com/get-docker/)
2. Clone the repo.
3. Run `docker compose up`

## Experiments

Example of `rick-and-morty-api` running alongside a `mongodb` container:
![Screenshot 2021-11-09 at 18 04 30](https://user-images.githubusercontent.com/11976836/140980384-27810bd1-780f-495c-9085-08e7901c18b1.png)

Example request made using [Insomnia](https://insomnia.rest/) to `/graphql`:
![Screenshot 2021-11-09 at 18 11 40](https://user-images.githubusercontent.com/11976836/140980598-0385f3b3-8315-457f-b378-a39b3ea7416f.png)


