### PR TITLE
Add limit query param

### DIFF
--- a/graphql/sources.js
+++ b/graphql/sources.js
@@ -17,8 +17,8 @@ class Character extends RESTDataSource {
     this.baseURL = `${baseUrl}/character`
   }
 
-  async characters({ filter, page }) {
-    return this.get('/', pruneObject({ ...filter, page }))
+  async characters({ filter, page, limit }) {
+    return this.get('/', pruneObject({ ...filter, page, limit }))
   }
   async charactersByIds({ ids }) {
     const data = await this.get('/' + ids)
@@ -35,8 +35,8 @@ class Location extends RESTDataSource {
     this.baseURL = `${baseUrl}/location`
   }
 
-  async locations({ filter, page }) {
-    return this.get('/', pruneObject({ ...filter, page }))
+  async locations({ filter, page, limit }) {
+    return this.get('/', pruneObject({ ...filter, page, limit }))
   }
   async locationsByIds({ ids }) {
     const data = await this.get('/' + ids)
@@ -53,8 +53,8 @@ class Episode extends RESTDataSource {
     this.baseURL = `${baseUrl}/episode`
   }
 
-  async episodes({ filter, page }) {
-    return this.get('/', pruneObject({ ...filter, page }))
+  async episodes({ filter, page, limit }) {
+    return this.get('/', pruneObject({ ...filter, page, limit }))
   }
   async episodesByIds({ ids }) {
     const data = await this.get('/' + ids)

--- a/handlers/operations.js
+++ b/handlers/operations.js
@@ -45,15 +45,17 @@ const queryById = async (Model, id) => {
 
 const getAll = async (req, res, next) => {
   const page = (req.query.page > 0 && req.query.page) || 1
-  const skip = page * collection.limit - collection.limit
+  const limit = req.query.page ?? 20
+  const skip = page * limit - limit
   const [, name] = req.path.split('/')
   const Model = models[name]
-  const opt = Object.assign(req.query, { skip })
+  const opt = Object.assign(req.query, { skip, limit })
 
   const { results, count } = await Model.findAndCount(opt)
 
   req.payload = {
     page,
+    limit,
     count,
     results,
   }

--- a/models/Character.js
+++ b/models/Character.js
@@ -48,7 +48,7 @@ characterSchema.statics.structure = (res) => {
   return Array.isArray(res) ? res.map(sortSchema) : sortSchema(res)
 }
 
-characterSchema.statics.findAndCount = async function ({ name, type, status, species, gender, skip }) {
+characterSchema.statics.findAndCount = async function ({ name, type, status, species, gender, skip, limit }) {
   const q = (key) => new RegExp(key && (/^male/i.test(key) ? `^${key}` : key.replace(/[^\w\s]/g, '\\$&')), 'i')
 
   const query = {
@@ -60,7 +60,7 @@ characterSchema.statics.findAndCount = async function ({ name, type, status, spe
   }
 
   const [data, count] = await Promise.all([
-    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(collection.limit).skip(skip),
+    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(limit).skip(skip),
     this.find(query).countDocuments(),
   ])
 

--- a/models/Episode.js
+++ b/models/Episode.js
@@ -29,7 +29,7 @@ episodeSchema.statics.structure = (res) => {
   return Array.isArray(res) ? res.map(sortSchema) : sortSchema(res)
 }
 
-episodeSchema.statics.findAndCount = async function ({ name, episode, skip }) {
+episodeSchema.statics.findAndCount = async function ({ name, episode, skip, limit }) {
   const q = (key) => new RegExp(key && key.replace(/[^\w\s]/g, '\\$&'), 'i')
 
   const query = {
@@ -38,7 +38,7 @@ episodeSchema.statics.findAndCount = async function ({ name, episode, skip }) {
   }
 
   const [data, count] = await Promise.all([
-    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(collection.limit).skip(skip),
+    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(limit).skip(skip),
     this.find(query).countDocuments(),
   ])
 

--- a/models/Location.js
+++ b/models/Location.js
@@ -29,7 +29,7 @@ locationSchema.statics.structure = (res) => {
   return Array.isArray(res) ? res.map(sortSchema) : sortSchema(res)
 }
 
-locationSchema.statics.findAndCount = async function ({ name, type, dimension, skip }) {
+locationSchema.statics.findAndCount = async function ({ name, type, dimension, skip, limit }) {
   const q = (key) => new RegExp(key && key.replace(/[^\w\s]/g, '\\$&'), 'i')
 
   const query = {
@@ -39,7 +39,7 @@ locationSchema.statics.findAndCount = async function ({ name, type, dimension, s
   }
 
   const [data, count] = await Promise.all([
-    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(collection.limit).skip(skip),
+    this.find(query).sort({ id: 1 }).select(collection.exclude).limit(limit).skip(skip),
     this.find(query).countDocuments(),
   ])
 

--- a/routes/middlewares.js
+++ b/routes/middlewares.js
@@ -6,8 +6,8 @@ const { baseUrl, message, collection } = require('../utils/helpers')
 const sanitizeQueryParams = (model) => query(collection.queries[model]).trim()
 
 const generatePageUrls = (req, res, next) => {
-  const { results, count, page } = req.payload
-  const pages = Math.ceil(count / collection.limit)
+  const { results, count, page, limit } = req.payload
+  const pages = Math.ceil(count / limit)
 
   if (page > pages) {
     res.status(404).json({ error: message.noPage })
@@ -30,6 +30,7 @@ const generatePageUrls = (req, res, next) => {
     info: {
       count,
       pages,
+      limit,
       next: page >= pages ? null : `${baseUrl}${req.path}?page=${parseInt(page) + 1}${qr}`,
       prev: page < 2 ? null : `${baseUrl}${req.path}?page=${parseInt(page) - 1}${qr}`,
     },

--- a/test/rest-character.js
+++ b/test/rest-character.js
@@ -248,6 +248,18 @@ describe('[REST][Character] pages', () => {
     expect(body.results[19]).to.include({ id: 40 })
   })
 
+  it('should limit items per page', async () => {
+    const { body } = await test('?page=2&limit=5')
+
+    expectStructure(body)
+    expect(body.info.prev.slice(-1)).to.equal('1')
+    expect(body.info.next.slice(-1)).to.equal('3')
+    expect(body.results).to.have.lengthOf(5)
+
+    expect(body.results[0]).to.include({ id: 21 })
+    expect(body.results[5]).to.include({ id: 25 })
+  })
+
   it('should get an error message', async () => {
     const res = await test('?page=12345')
 

--- a/test/rest-episode.js
+++ b/test/rest-episode.js
@@ -165,6 +165,18 @@ describe('[REST][Episode] pages', () => {
 
     expect(body.results[0]).to.include({ id: 1 })
   })
+
+  it('should limit items per page', async () => {
+    const { body } = await test('?page=1&limit=5')
+
+    expectStructure(body)
+    expect(body.info.prev).to.be.null
+    expect(body.info.next.slice(-1)).to.equal('2')
+    expect(body.results).to.have.lengthOf(5)
+
+    expect(body.results[0]).to.include({ id: 1 })
+    expect(body.results[4]).to.include({ id: 5 })
+  })
 })
 
 describe('[REST][Episode] ?page=12345 ', async () => {

--- a/test/rest-location.js
+++ b/test/rest-location.js
@@ -197,6 +197,18 @@ describe('[REST][Location] pages', () => {
     expect(body.results[0]).to.include({ id: 1 })
     expect(body.results[19]).to.include({ id: 20 })
   })
+
+  it('should limit items per page', async () => {
+    const { body } = await test('?page=1&limit=5')
+
+    expectStructure(body)
+    expect(body.info.prev).to.be.null
+    expect(body.info.next.slice(-1)).to.equal('2')
+    expect(body.results).to.have.lengthOf(5)
+
+    expect(body.results[0]).to.include({ id: 1 })
+    expect(body.results[4]).to.include({ id: 5 })
+  })
 })
 
 describe('[REST][Location] ?page=12345 ', async () => {

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -11,7 +11,6 @@ const message = {
 
 const collection = {
   exclude: '-_id -author -__v -edited',
-  limit: 20,
   queries: {
     character: ['name', 'status', 'species', 'type', 'gender'],
     episode: ['name', 'episode'],


### PR DESCRIPTION
Very nice API!

We noticed the items per page were fixed at 20 items and we need this to be dynamic to test out our pagination component. To account for this I've added support for a `limit` query string parameter.

Note: Since I don't have the data in a local DB, I haven't been able to actually test these changes. Please test them out locally before merging, I might have forgotten about something.

Thanks! 