### PR TITLE
fix: characters type  - characters.results obj

### DIFF
--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -50,7 +50,9 @@ const typeDefs = gql`
 
   type Characters {
     info: Info
-    results: [Character]
+    characters: {
+      results: [Character]
+    }
   }
 
   type Locations {


### PR DESCRIPTION
When generating types from graphql schema, it says `data.characters.results` does not exist
<img width="518" alt="image" src="https://user-images.githubusercontent.com/29252011/192144394-c3d535aa-4fc3-4cfd-ba44-ffeff4370bf8.png">
<img width="219" alt="image" src="https://user-images.githubusercontent.com/29252011/192144408-4606d41b-2957-453e-b82b-8e2eabe8467b.png">

But when playing around with the request and on [apollo graphql studio ](https://studio.apollographql.com/public/rick-and-morty-a3b90u/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAIq6FHAA6SRRUAFgIZ5NQr4DOlNddeCTjAA2KbtVp86SJol5SiASzDypiuEwDmCVUQC%2B8g0iMgANCABuLRUwBGwwRhDU88qiEYs2HPAEkVGETuAIzuVK7GIHpAA&variant=current), we can see that data comes from `data.characters.result` and not from `data.result` as type says.

<img width="193" alt="image" src="https://user-images.githubusercontent.com/29252011/192144495-336f0720-0451-431e-af30-797829288df8.png">

[Try on Apollo GraphQL Studio](https://studio.apollographql.com/public/rick-and-morty-a3b90u/explorer?explorerURLState=N4IgJg9gxgrgtgUwHYBcQC4QEcYIE4CeABAIq6FHAA6SRRUAFgIZ5NQr4DOlNddeCTjAA2KbtVp86SJol5SiASzDypiuEwDmCVUQC%2B8g0iMgANCABuLRUwBGwwRhDU88qiEYs2HPAEkVGETuAIzuVK7GIHpAA&variant=current)

When working with codegen, I had to manually change, which is not a good idea, so I tried changing it on typeDefs on graphQL